### PR TITLE
Rectify nexus phylogeny syntax

### DIFF
--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -143,7 +143,7 @@ write_nex <- function(phy, label="sp", output_file){
     }
 
 
-    String_final <- paste("tree = ", String, ";", sep="")
+    String_final <- paste("Tree tree = ", String, ";", sep="")
     String_final <- (paste("#NEXUS",
                            "begin trees;",
                            String_final,


### PR DESCRIPTION
Existing output is missing necessary the `Tree ` prefix. Generated Nexus files wouldn't open in other software. See `https://en.wikipedia.org/wiki/Nexus_file` for syntax example.