### PR TITLE
Fix typo in design_landscape vignette

### DIFF
--- a/vignettes/design_landscape.Rmd
+++ b/vignettes/design_landscape.Rmd
@@ -117,8 +117,8 @@ for (timestep in 1:Ntimesteps){ # temporal loop
         prec_dataframe[counting,1]<-x
         prec_dataframe[counting,2]<-y
       }
-      temp_dataframe[counting,2+timestep]<-temp_dataframe[x,y,timestep]
-      prec_dataframe[counting,2+timestep]<-prec_dataframe[x,y,timestep]
+      temp_dataframe[counting,2+timestep]<-temp_matrix[x,y,timestep]
+      prec_dataframe[counting,2+timestep]<-prec_matrix[x,y,timestep]
       counting<-counting+1
     }
   }


### PR DESCRIPTION
Appears to have been introduced by an erroneous renaming? https://github.com/project-gen3sis/R-package/commit/130bc184732b0f78a21b9499ce90944c66547aee?diff=unified&w=0#r134004700